### PR TITLE
Add functionality to deal with duplicates

### DIFF
--- a/src/main/java/duke/commands/Command.java
+++ b/src/main/java/duke/commands/Command.java
@@ -1,5 +1,7 @@
 package duke.commands;
 
+import static duke.ui.Ui.LS;
+
 import duke.storage.Storage;
 import duke.tasks.TaskList;
 import duke.ui.Ui;
@@ -10,5 +12,7 @@ import duke.ui.Ui;
 public abstract class Command {
     public abstract void execute(TaskList tl, Ui ui, Storage s);
     public abstract boolean isExit();
-
+    public void handleDuplicate(Ui ui) {
+        ui.display("I did not add this task as it is a duplicate!");
+    }
 }

--- a/src/main/java/duke/commands/DeadlineCommand.java
+++ b/src/main/java/duke/commands/DeadlineCommand.java
@@ -24,9 +24,13 @@ public class DeadlineCommand extends Command {
     @Override
     public void execute(TaskList tl, Ui ui, Storage s) {
         Deadline t = new Deadline(this.desc, this.by);
-        tl.addTask(t);
-        s.addTask(t.toText());
-        ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        if (tl.isDuplicate(t)) {
+            handleDuplicate(ui);
+        } else {
+            tl.addTask(t);
+            s.addTask(t.toText());
+            ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        }
     }
     @Override
     public boolean isExit() {

--- a/src/main/java/duke/commands/EventCommand.java
+++ b/src/main/java/duke/commands/EventCommand.java
@@ -26,9 +26,13 @@ public class EventCommand extends Command {
     @Override
     public void execute(TaskList tl, Ui ui, Storage s) {
         Event t = new Event(this.desc, this.from, this.to);
-        tl.addTask(t);
-        s.addTask(t.toText());
-        ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        if (tl.isDuplicate(t)) {
+            handleDuplicate(ui);
+        } else {
+            tl.addTask(t);
+            s.addTask(t.toText());
+            ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        }
     }
     @Override
     public boolean isExit() {

--- a/src/main/java/duke/commands/TodoCommand.java
+++ b/src/main/java/duke/commands/TodoCommand.java
@@ -18,9 +18,13 @@ public class TodoCommand extends Command {
     @Override
     public void execute(TaskList tl, Ui ui, Storage s) {
         ToDo t = new ToDo(desc);
-        tl.addTask(t);
-        s.addTask(t.toText());
-        ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        if (tl.isDuplicate(t)) {
+            handleDuplicate(ui);
+        } else {
+            tl.addTask(t);
+            s.addTask(t.toText());
+            ui.display("Got it. I've added this task:" + LS + t + LS + tl.numTasksMsg());
+        }
     }
     @Override
     public boolean isExit() {

--- a/src/main/java/duke/enums/CommandType.java
+++ b/src/main/java/duke/enums/CommandType.java
@@ -19,7 +19,7 @@ public enum CommandType {
     DEADLINE("deadline", new DukeException("Invalid format for Deadline." + LS
             + "Usage: deadline <task> /by <" + DATE_TIME_FORMAT + ">")),
     EVENT("event", new DukeException("Invalid format for Event." + LS
-            + "Usage: <task> /from <" + DATE_TIME_FORMAT + "> /to <" + DATE_TIME_FORMAT + ">")),
+            + "Usage: event <task> /from <" + DATE_TIME_FORMAT + "> /to <" + DATE_TIME_FORMAT + ">")),
     INCORRECT("incorrect", new DukeException("OOPS!!! I'm sorry, but I don't know what that means :-("));
     private String word;
     private DukeException e;

--- a/src/main/java/duke/tasks/TaskList.java
+++ b/src/main/java/duke/tasks/TaskList.java
@@ -24,6 +24,16 @@ public class TaskList {
         tasks.remove(i);
     }
 
+    public boolean isDuplicate(Task newTask) {
+        boolean isDup = false;
+        for (Task t : this.tasks) {
+            if (newTask.toText().equals(t.toText())) {
+                isDup = true;
+            }
+        }
+        return isDup;
+    }
+
     /**
      * Mark Task object at index i.
      */


### PR DESCRIPTION
Currently new ToDo, Deadline and Event tasks are added to the task list and storage file even if they are duplicates.

We should avoid doing this to clutter the user's tasklist with duplicate tasks that the user had forgotten they added previously

Let's prevent the addition of duplicate tasks and display to the user in the GUI that the task was not added as it already exists in the tasklist

We still allow user to add duplicate of the same task if one is marked and one is unmarked as the user might want to keep track of the task in both states